### PR TITLE
updated travis build to replace -

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,9 @@ script:
   - busted --verbose --coverage
 
 after_success:
-- luacov-coveralls -i $TRAVIS_BUILD_DIR/lua-complete
+- INSTALL=`echo $TRAVIS_BUILD_DIR/lua_install | sed 's/-/%-/'`
+- echo $INSTALL
+- luacov-coveralls -e $INSTALL
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script:
   - busted --verbose --coverage
 
 after_success:
+- echo $TRAVIS_BUILD_DIR
 - luacov-coveralls -e $TRAVIS_BUILD_DIR/lua_install
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,7 @@ script:
   - busted --verbose --coverage
 
 after_success:
-- echo $TRAVIS_BUILD_DIR
-- luacov-coveralls -e $TRAVIS_BUILD_DIR/lua_install
+- luacov-coveralls -i $TRAVIS_BUILD_DIR/lua-complete
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,8 @@ script:
   - busted --verbose --coverage
 
 after_success:
-- INSTALL=`echo $TRAVIS_BUILD_DIR/lua_install | sed 's/-/%-/'`
-- echo $INSTALL
-- luacov-coveralls -e $INSTALL
+- EXCLUDE_DIR=`echo $TRAVIS_BUILD_DIR/lua_install | sed 's/-/%-/'`
+- luacov-coveralls -e $EXCLUDE_DIR
 
 branches:
   except:


### PR DESCRIPTION
luacov uses string.match under the covers when including/excluding file paths. The "-" is a magic character that needs to be escaped. This adds the escape.